### PR TITLE
Fix support for extended frames

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 project(usbcan)
 
 set(CMAKE_CXX_STANDARD 17 "-pthread")

--- a/src/canusb.c
+++ b/src/canusb.c
@@ -363,8 +363,12 @@ int send_data_frame(const unsigned char *data, const int data_length, const CANU
     frame = (unsigned char *) malloc((size_t) frame_size);
     frame[0] = (unsigned char) PACKET_START_FLAG;
     frame[frame_size - 1] = PACKET_END_FLAG;
-    frame[1] = (unsigned char) (0xc0 | data_length);
 
+    if (CANUSB_FRAME_STANDARD == type) {
+        frame[1] = (unsigned char) (0xc0 | data_length);
+    } else {
+        frame[1] = (unsigned char) (0xe0 | data_length);
+    }
 
     if (CANUSB_FRAME_STANDARD == type) {
         frame[2] = (unsigned char) (id & 0xFF);


### PR DESCRIPTION
According to Wilfried Voss' [protocol documentation](https://copperhilltech.com/blog/usbcan-analyzer-usb-to-can-bus-serial-protocol-definition/), when sending an extended CAN data frame, the 3rd highest bit of the second byte should be set to 1.