### PR TITLE
kmod: fix wrong bitwise operation on Type

### DIFF
--- a/src/module/hlcan.c
+++ b/src/module/hlcan.c
@@ -328,7 +328,7 @@ static void slc_encaps(struct slcan *sl, struct can_frame *cf)
 	*pos = HLCAN_FRAME_PREFIX;
 	*pos |= cf->can_dlc;
 	if (cf->can_id & CAN_RTR_FLAG) {
-		*pos &= HLCAN_FLAG_RTR;
+		*pos |= HLCAN_FLAG_RTR;
 	}
 
 	/* setup the frame id id */


### PR DESCRIPTION
We have to enable/disable it not clear the register content

Tyep:
  - 0xc0 Tyep
  - bit5(0: standard frame, 1: extended)
  - bit4 (0: data frame, 1: remote frame)
  - Bit0~3 Frame data length

The tx red led now blinks when the  RTR flag is set in on.