### PR TITLE
Explicitly declare function in question

### DIFF
--- a/src/module/hlcan.c
+++ b/src/module/hlcan.c
@@ -175,6 +175,16 @@ static struct net_device **slcan_devs;
   *			STANDARD SLCAN DECAPSULATION			 *
   ************************************************************************/
 
+static inline void *skb_put_data(struct sk_buff *skb, const void *data,
+				 unsigned int len)
+{
+	void *tmp = skb_put(skb, len);
+
+	memcpy(tmp, data, len);
+
+	return tmp;
+}
+
 /* Send one completely decapsulated can_frame to the network layer */
 static void slc_bump(struct slcan *sl)
 {


### PR DESCRIPTION
Fixes the following error seen on Nvidia Jetson AGX due to the fact that the kernel treats the implicit-function-declaration warning as an error:

`:~/usb-can/src/module$ make
make -C /lib/modules/4.9.140-tegra/build/ M=/home/tibi/usb-can/src/module modules
make[1]: Entering directory '/usr/src/linux-headers-4.9.140-tegra-ubuntu18.04_aarch64/kernel-4.9'
  CC [M]  /home/tibi/usb-can/src/module/hlcan.o
/home/tibi/usb-can/src/module/hlcan.c: In function ‘slc_bump’:
/home/tibi/usb-can/src/module/hlcan.c:231:2: error: implicit declaration of function ‘skb_put_data’; did you mean ‘skb_add_data’? [-Werror=implicit-function-declaration]
  skb_put_data(skb, &cf, sizeof(struct can_frame));
  ^~~~~~~~~~~~
  skb_add_data
cc1: some warnings being treated as errors
scripts/Makefile.build:341: recipe for target '/home/tibi/usb-can/src/module/hlcan.o' failed
make[2]: *** [/home/tibi/usb-can/src/module/hlcan.o] Error 1
Makefile:1629: recipe for target '_module_/home/tibi/usb-can/src/module' failed
make[1]: *** [_module_/home/tibi/usb-can/src/module] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-4.9.140-tegra-ubuntu18.04_aarch64/kernel-4.9'
Makefile:11: recipe for target 'all' failed
make: *** [all] Error 2
`