### PR TITLE
Fix driver for Linux kernel > 5.13

### DIFF
--- a/src/module/hlcan.c
+++ b/src/module/hlcan.c
@@ -764,15 +764,27 @@ static void slcan_close(struct tty_struct *tty)
 	/* This will complete via sl_free_netdev */
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
+static void slcan_hangup(struct tty_struct *tty)
+{
+	slcan_close(tty);
+	return;
+}
+#else
 static int slcan_hangup(struct tty_struct *tty)
 {
 	slcan_close(tty);
 	return 0;
 }
+#endif
 
 /* Perform I/O control on an active SLCAN channel. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+static int slcan_ioctl(struct tty_struct *tty, unsigned int cmd, unsigned long arg)
+#else
 static int slcan_ioctl(struct tty_struct *tty, struct file *file,
 		       unsigned int cmd, unsigned long arg)
+#endif
 {
 	struct slcan *sl = (struct slcan *) tty->disc_data;
 
@@ -794,7 +806,11 @@ static int slcan_ioctl(struct tty_struct *tty, struct file *file,
 		return 0;
 
 	default:
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
+		return tty_mode_ioctl(tty, cmd, arg);
+#else
 		return tty_mode_ioctl(tty, file, cmd, arg);
+#endif
 	}
 }
 

--- a/src/module/hlcan.c
+++ b/src/module/hlcan.c
@@ -187,8 +187,9 @@ static void slc_bump(struct slcan *sl)
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 13, 0)
         cf.can_id = GET_FRAME_ID(sl->rbuff);
 #else
-        cf.len = GET_DLC(*cmd);
+	cf.len = GET_DLC(*cmd);
 #endif
+
 	if (IS_REMOTE(*cmd)){
 		cf.can_id |= CAN_RTR_FLAG;
 	}
@@ -202,13 +203,13 @@ static void slc_bump(struct slcan *sl)
 	/* RTR frames may have a dlc > 0 but they never have any data bytes */
 	if (!(cf.can_id & CAN_RTR_FLAG)) {
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 13, 0)
-          memcpy(cf.data,
+		memcpy(cf.data,
 			cmd + data_start,
 			cf.can_dlc);
 #else
-          memcpy(cf.data,
-                 cmd + data_start,
-                 cf.len);
+		memcpy(cf.data,
+			cmd + data_start,
+			cf.len);
 #endif
 	}
 
@@ -232,7 +233,7 @@ static void slc_bump(struct slcan *sl)
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 13, 0)
 	sl->dev->stats.rx_bytes += cf.can_dlc;
 #else
-        sl->dev->stats.rx_bytes += cf.len;
+	sl->dev->stats.rx_bytes += cf.len;
 #endif
 	netif_rx(skb);
 }

--- a/src/module/hlcan.c
+++ b/src/module/hlcan.c
@@ -184,8 +184,9 @@ static void slc_bump(struct slcan *sl)
 	/* idx 0 = packet header, skip it */
 	unsigned char *cmd = sl->rbuff + 1;
 
+	cf.can_id = GET_FRAME_ID(sl->rbuff);
+
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 13, 0)
-        cf.can_id = GET_FRAME_ID(sl->rbuff);
         cf.can_dlc = GET_DLC(*cmd);
 #else
 	cf.len = GET_DLC(*cmd);

--- a/src/module/hlcan.c
+++ b/src/module/hlcan.c
@@ -186,6 +186,7 @@ static void slc_bump(struct slcan *sl)
 
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 13, 0)
         cf.can_id = GET_FRAME_ID(sl->rbuff);
+        cf.can_dlc = GET_DLC(*cmd);
 #else
 	cf.len = GET_DLC(*cmd);
 #endif


### PR DESCRIPTION
The Linux TTY line discipline API was changed, compared to 5.x kernel. See https://docs.kernel.org/driver-api/tty/tty_ldisc.html, so that the module does not build for recent kernel version.

In addition, the can_id was not initialized when compiled with kernel version > 5.13.